### PR TITLE
docs: fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The schematic will:
 - install necessary dependencies
 - configure `serve`, `build`, and `test` architects of your app (these will use a custom builder to allow for custom webpack configurations)
 
-Once all that is done, we can take adventage of this library and define some event streams in our templates 🎉.
+Once all that is done, we can take advantage of this library and define some event streams in our templates 🎉.
 
 ## Syntax
 


### PR DESCRIPTION
Hi guys,

I found a tiny typo in the README.md - not sure if this actually warrants a PR, but here we go anyway :)